### PR TITLE
Fix rare bug that was a result of missing keys

### DIFF
--- a/usda/domain.py
+++ b/usda/domain.py
@@ -267,13 +267,15 @@ class FoodReport(UsdaObject):
         food = report['food']
         food_group = None if type == "Basic" or type == "Statistics" \
             else food["fg"]
+        if all(('idv' in fn and 'desc' in fn) for fn in report["footnotes"]):
+            foot_notes = [ListItem(fn['idv'], fn['desc']) for fn in report["footnotes"]]
+        else:
+            foot_notes = None
         return FoodReport(
             food=Food.from_response_data(food),
             nutrients=FoodReport._get_nutrients(food["nutrients"]),
             report_type=type,
-            foot_notes=[
-                ListItem(fn['idv'], fn['desc']) for fn in report["footnotes"]
-            ],
+            foot_notes=foot_notes,
             food_group=food_group,
         )
 

--- a/usda/domain.py
+++ b/usda/domain.py
@@ -267,15 +267,13 @@ class FoodReport(UsdaObject):
         food = report['food']
         food_group = None if type == "Basic" or type == "Statistics" \
             else food["fg"]
-        if all(('idv' in fn and 'desc' in fn) for fn in report["footnotes"]):
-            foot_notes = [ListItem(fn['idv'], fn['desc']) for fn in report["footnotes"]]
-        else:
-            foot_notes = None
         return FoodReport(
             food=Food.from_response_data(food),
             nutrients=FoodReport._get_nutrients(food["nutrients"]),
             report_type=type,
-            foot_notes=foot_notes,
+            foot_notes=[
+                ListItem(fn['id'], fn['desc']) for fn in report["footnotes"]
+            ],
             food_group=food_group,
         )
 
@@ -429,7 +427,7 @@ class FoodReportV2(FoodReport):
             food_group=None,
             report_type=food['type'],
             foot_notes=[
-                ListItem(fn['idv'], fn['desc']) for fn in food['footnotes']
+                ListItem(fn['id'], fn['desc']) for fn in food['footnotes']
             ],
             nutrients=FoodReport._get_nutrients(food['nutrients']),
             sources=[


### PR DESCRIPTION
food_report = client.get_food_report(meal_data.id)
  File "venv\lib\site-packages\usda\client.py", line 195, in get_food_report
    self.get_food_report_raw(type=report_type.value, ndbno=ndb_food_id)
  File "venv\lib\site-packages\usda\domain.py", line 275, in from_response_data
    ListItem(fn['idv'], fn['desc']) for fn in report["footnotes"]
  File "venv\lib\site-packages\usda\domain.py", line 275, in <listcomp>
    ListItem(fn['idv'], fn['desc']) for fn in report["footnotes"]
KeyError: 'idv'

https://fdc.nal.usda.gov/fdc-app.html#/food-details/168204/nutrients
Bug can be found when trying to request the report for this product